### PR TITLE
[FIX] Default Get + Show OU on Small Form

### DIFF
--- a/product_operating_unit/models/product_template.py
+++ b/product_operating_unit/models/product_template.py
@@ -13,9 +13,10 @@ class ProductTemplate(models.Model):
     def _default_operating_unit_ids(self):
         if self.categ_id and self.categ_id.operating_unit_ids:
             return [(6, 0, self.categ_id.operating_unit_ids.ids)]
-        return [(6, 0,
-                 [self.env['res.users'].operating_unit_default_get(
-                     self.env.uid).id])]
+        if self.env.user.default_operating_unit_id:
+            return [(6, 0,
+                    [self.env['res.users'].operating_unit_default_get(
+                        self.env.uid).id])]
 
     operating_unit_ids = fields.Many2many(
         'operating.unit',

--- a/product_operating_unit/views/product_template_view.xml
+++ b/product_operating_unit/views/product_template_view.xml
@@ -22,7 +22,7 @@
     <record id="product_template_only_form_view" model="ir.ui.view">
         <field name="name">product.template_form</field>
         <field name="model">product.template</field>
-        <field name="inherit_id" ref="product.product_template_only_form_view" />
+        <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
             <field name="company_id" position="after">
                 <field name="operating_unit_ids"


### PR DESCRIPTION
If the user does not have a default_operating_unit_id and is trying to create a product on another form, the default method will try and create an empty OU. This throws an permissions error for people who do not have OU management access. We also cannot see the OU field on the form that appears when you create a Product from another form (Purchase Order > Purchase Order Lines > Create and Edit).